### PR TITLE
feat: add initial observability skeleton

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,23 @@
-.PHONY: build run test
+.PHONY: all build test run docker helm
+
+GO ?= go
+
+all: build
 
 build:
-@echo "Building services"
-
-run:
-@echo "Running services"
+	$(GO) build ./...
 
 test:
-go test ./...
+	$(GO) test ./...
+
+run:	# 本地快速起网关（其余用 compose/helm）
+	go run ./cmd/gateway
+
+docker:
+	docker build -t stratolake/gateway:dev ./cmd/gateway
+	docker build -t stratolake/schema-registry:dev ./cmd/schema-registry
+	docker build -t stratolake/pg-writer:dev ./cmd/pg-writer
+	docker build -t stratolake/ch-writer:dev ./cmd/ch-writer
+
+helm:
+	helm upgrade --install stratolake deployments/helm -n stratolake --create-namespace

--- a/agents/vector/vector.toml
+++ b/agents/vector/vector.toml
@@ -12,15 +12,33 @@ source = '''
 .structured = parse_json!(string!(.message))
 '''
 
+# 方案 A：走网关统一入口（推荐，后续易扩展到 Kafka/Flight）
 [sinks.gateway_metrics]
 type = "http"
 inputs = ["prom"]
-uri = "http://localhost:8080/write/metrics"
+uri = "http://gateway:8080/write/metrics"
 encoding.codec = "json"
 
 [sinks.gateway_logs]
 type = "http"
 inputs = ["jsonify_logs"]
-uri = "http://localhost:8080/write/logs"
+uri = "http://gateway:8080/write/logs"
 encoding.codec = "json"
 
+# 方案 B：直写（PoC/旁路）
+# [sinks.pg]
+# type     = "postgresql"
+# inputs   = ["prom", "jsonify_logs"]
+# endpoint = "postgresql://user:pass@pg:5432/metrics"
+# database = "metrics"
+# table    = "observability_events"
+# mode     = "insert"
+# compression = "zstd"
+
+# [sinks.ch]
+# type     = "clickhouse"
+# inputs   = ["jsonify_logs"]
+# endpoint = "http://clickhouse:8123"
+# database = "default"
+# table    = "logs"
+# compression = "gzip"

--- a/configs/gateway.yaml
+++ b/configs/gateway.yaml
@@ -1,1 +1,22 @@
-# TODO: configuration for gateway service
+server:
+  http_listen: ":8080"
+
+ingest:
+  enable_rest: true
+  enable_grpc: true
+  enable_otel: true       # OTLP/HTTP 可选
+  enable_flight: false    # 后续扩展
+
+routes:
+  metrics:
+    writer: "pg"          # pg-writer 服务
+  logs:
+    writer: "ch"          # ch-writer 服务
+
+upstreams:
+  pg_writer: "http://pg-writer:8091"
+  ch_writer: "http://ch-writer:8092"
+
+o11y:
+  prometheus: ":9464"
+  trace: "stdout"

--- a/grafana/provisioning/datasources/datasources.yaml
+++ b/grafana/provisioning/datasources/datasources.yaml
@@ -1,3 +1,22 @@
 apiVersion: 1
+datasources:
+  - name: Stratolake-PG
+    type: postgres
+    access: proxy
+    url: pg:5432
+    user: metrics
+    secureJsonData:
+      password: ${PG_PASSWORD}
+    jsonData:
+      database: metrics
+      sslmode: disable
+      timescaledb: true
+      timeColumn: time
 
-# TODO: define Grafana datasources
+  - name: Stratolake-CH
+    type: grafana-clickhouse-datasource
+    access: proxy
+    url: http://clickhouse:8123
+    jsonData:
+      defaultDatabase: default
+      queryTimeout: 60

--- a/migrations/clickhouse/0001_logs_events.sql
+++ b/migrations/clickhouse/0001_logs_events.sql
@@ -1,2 +1,11 @@
--- Logs events schema
-
+CREATE TABLE IF NOT EXISTS logs_events (
+  timestamp DateTime,
+  app       String,
+  host      String,
+  trace_id  String,
+  message   String,
+  labels    Nested(k String, v String)
+)
+ENGINE = MergeTree()
+PARTITION BY toYYYYMMDD(timestamp)
+ORDER BY (timestamp, app);

--- a/migrations/postgres/0001_init.sql
+++ b/migrations/postgres/0001_init.sql
@@ -1,2 +1,10 @@
--- Initial PostgreSQL schema
+-- TimescaleDB 扩展（如已启用可忽略）
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
+-- Schema registry
+CREATE TABLE IF NOT EXISTS table_registry (
+  table_name  TEXT PRIMARY KEY,
+  schema      JSONB NOT NULL,
+  created_at  TIMESTAMPTZ DEFAULT now()
+);

--- a/migrations/postgres/0002_metrics_events.sql
+++ b/migrations/postgres/0002_metrics_events.sql
@@ -1,2 +1,10 @@
--- Metrics events schema
-
+CREATE TABLE IF NOT EXISTS metrics_events (
+  time        TIMESTAMPTZ NOT NULL,
+  app         TEXT,
+  host        TEXT,
+  labels      JSONB,
+  value       DOUBLE PRECISION,
+  trace_id    TEXT,
+  level       TEXT
+);
+SELECT create_hypertable('metrics_events', 'time', if_not_exists => TRUE, migrate_data => TRUE);


### PR DESCRIPTION
## Summary
- add initial TimescaleDB and ClickHouse migrations
- wire Vector agent, gateway config, and Grafana datasources
- document architecture and provide developer Makefile

## Testing
- `go test ./...` *(fails: cannot load module cmd/gateway listed in go.work file)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b3d2dee08332a45d93dfe0b485c9