### PR TITLE
fix: include postgres driver for migrations

### DIFF
--- a/observe-bridge/Makefile
+++ b/observe-bridge/Makefile
@@ -24,7 +24,7 @@ init-db:
 	psql $(PG_URL) -c 'SELECT 1'
 
 migrate:
-	$(GO) install github.com/golang-migrate/migrate/v4/cmd/migrate@latest
+	$(GO) install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
 	migrate -path migrations/postgres -database $(PG_URL) up
 
 integration-tests: build


### PR DESCRIPTION
## Summary
- ensure golang-migrate CLI is built with postgres driver

## Testing
- `make integration-tests` *(fails: psql: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b2ed5f48833287ff80619b624208