### PR TITLE
feat: implement oo stream endpoint

### DIFF
--- a/docs/observe-bridge/api.md
+++ b/docs/observe-bridge/api.md
@@ -10,7 +10,7 @@
     - `from`: 窗口起始时间 (RFC3339)。
     - `to`: 窗口结束时间 (RFC3339)。
   - 响应: HTTP `200`，返回以换行符分隔的 JSON 流，每行一个 `oo.Record`。
-  - 说明: 按窗口流式获取 OO (logs/metrics/traces)，回调 `fn(oo.Record)` 处理每条记录。
+  - 说明: 按窗口流式获取 OO 数据，`oo.Record` 中包含 `type=logs|metrics|traces` 字段，回调 `fn(oo.Record)` 处理每条记录。
 
 - **pkg/agg**
   - API: `Feed(rec) / Drain()`

--- a/observe-bridge/etl/pkg/oo/oo.go
+++ b/observe-bridge/etl/pkg/oo/oo.go
@@ -1,16 +1,56 @@
 package oo
 
 import (
+	"bufio"
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
 
 	"github.com/xscopehub/xscopehub/etl/pkg/window"
 )
 
 // Record represents a generic OpenObserve record.
-type Record struct{}
+type Record map[string]any
 
-// Stream reads records for the tenant in the given window and invokes fn for each record.
+// Stream reads logs, metrics, and traces for the tenant in the given window and invokes fn for each record.
+// It queries the OpenObserve OTEL HTTP API for each data type and streams NDJSON results.
 func Stream(ctx context.Context, tenant string, w window.Window, fn func(Record)) error {
-	// TODO: implement streaming from OpenObserve
+	endpoint := os.Getenv("OPENOBSERVE_URL")
+	if endpoint == "" {
+		return fmt.Errorf("OPENOBSERVE_URL not set")
+	}
+	auth := os.Getenv("OPENOBSERVE_AUTH")
+	client := http.Client{}
+	types := []string{"logs", "metrics", "traces"}
+	for _, typ := range types {
+		url := fmt.Sprintf("%s%s/_search?start=%d&end=%d", endpoint, typ, w.From.UnixMilli(), w.To.UnixMilli())
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return err
+		}
+		if auth != "" {
+			req.Header.Set("Authorization", auth)
+		}
+		req.Header.Set("Accept", "application/x-ndjson")
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			var rec Record
+			if err := json.Unmarshal(scanner.Bytes(), &rec); err != nil {
+				continue
+			}
+			rec["type"] = typ
+			if tenant != "" {
+				rec["tenant"] = tenant
+			}
+			fn(rec)
+		}
+		resp.Body.Close()
+	}
 	return nil
 }

--- a/observe-bridge/integration-test-cases/oo_stream_test.go
+++ b/observe-bridge/integration-test-cases/oo_stream_test.go
@@ -3,6 +3,7 @@ package integration_test
 import (
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 )
@@ -19,8 +20,12 @@ func TestOOStream(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("unexpected status: %d", resp.StatusCode)
 	}
-	buf := make([]byte, 1)
-	if _, err := resp.Body.Read(buf); err != nil && err != io.EOF {
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
 		t.Fatalf("failed to read stream: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) < 3 {
+		t.Fatalf("expected at least 3 records, got %d", len(lines))
 	}
 }


### PR DESCRIPTION
## Summary
- stream newline-delimited JSON records for /oo/stream
- parse window params from RFC3339 or unix seconds
- add basic oo.Stream implementation
- stream logs, metrics, and traces with type field
- test /oo/stream endpoint for multiple record types
- query OpenObserve via OTEL HTTP streaming for logs, metrics, and traces

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68c1746cd91c833283fda7f64c8151c8